### PR TITLE
Revert failed release prepare commit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 
   <modelVersion>4.0.0</modelVersion>
   <artifactId>casesvc-api</artifactId>
-  <version>10.49.2</version>
+  <version>10.49.2-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>CTP : CaseServiceApi</name>
@@ -133,7 +133,6 @@
     <connection>scm:git:https://github.com/ONSdigital/rm-casesvc-api</connection>
     <developerConnection>scm:git:https://github.com/ONSdigital/rm-casesvc-api</developerConnection>
     <url>https://github.com/ONSdigital/rm-casesvc-api</url>
-    <tag>casesvc-api-10.49.2</tag>
   </scm>
 
 </project>


### PR DESCRIPTION
The build failed because of missing configuration which left the release process half complete. This change reverts the failed deployment.