### PR TITLE
remove unneeded respondent_add_survey case event

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/representation/CategoryDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/representation/CategoryDTO.java
@@ -76,8 +76,7 @@ public class CategoryDTO {
     VERIFICATION_CODE_SENT,
     COLLECTION_INSTRUMENT_ERROR,
     COMPLETED_BY_PHONE,
-    RESPONDENT_EMAIL_AMENDED,
-    RESPONDENT_ADD_SURVEY;
+    RESPONDENT_EMAIL_AMENDED;
 
     /**
      * Gets CategoryName enum from string


### PR DESCRIPTION
I managed to push this up to master directly and it's not needed.