### PR TITLE
Add replaced category

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/representation/CategoryDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/representation/CategoryDTO.java
@@ -78,7 +78,8 @@ public class CategoryDTO {
     VERIFICATION_CODE_SENT,
     COLLECTION_INSTRUMENT_ERROR,
     COMPLETED_BY_PHONE,
-    RESPONDENT_EMAIL_AMENDED;
+    RESPONDENT_EMAIL_AMENDED,
+    REPLACED;
 
     /**
      * Gets CategoryName enum from string


### PR DESCRIPTION
Add replaced category in order to check if a B case is being replaced during deactivating an account or disabling an enrolment in order to assign correct party id to case.