### PR TITLE
US050d-Add no longer required status and case event category

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/representation/CaseGroupStatus.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/representation/CaseGroupStatus.java
@@ -5,5 +5,5 @@ package uk.gov.ons.ctp.response.casesvc.representation;
  *  Updated depending on enrolled respondent actions
  */
 public enum CaseGroupStatus {
- NOTSTARTED, INPROGRESS, COMPLETE, COMPLETEDBYPHONE, REOPENED
+  NOTSTARTED, INPROGRESS, COMPLETE, COMPLETEDBYPHONE, REOPENED, NOLONGERREQUIRED
 }

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/representation/CategoryDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/representation/CategoryDTO.java
@@ -79,7 +79,8 @@ public class CategoryDTO {
     COLLECTION_INSTRUMENT_ERROR,
     COMPLETED_BY_PHONE,
     RESPONDENT_EMAIL_AMENDED,
-    REPLACED;
+    REPLACED,
+    NO_LONGER_REQUIRED;
 
     /**
      * Gets CategoryName enum from string


### PR DESCRIPTION
[Trello](https://trello.com/c/2a1r2ZJM/105-us050d-int-manually-change-the-response-status-for-a-given-ru-survey-ce-to-no-longer-required-l)
[Confluence](https://digitaleq.atlassian.net/wiki/spaces/RASB/pages/282132485/US050d+INT+Manually+change+the+response+status+for+a+given+RU+Survey+CE+to+No+Longer+Required+L)