### PR TITLE
Add exerciseId and partyId to case message for action service

### DIFF
--- a/src/main/resources/casesvc/xsd/outbound/caseNotification.xsd
+++ b/src/main/resources/casesvc/xsd/outbound/caseNotification.xsd
@@ -8,6 +8,8 @@
     <xs:all>
       <xs:element name="caseId" type="xs:string" minOccurs="1"/>
       <xs:element name="actionPlanId" type="xs:string" minOccurs="1"/>
+      <xs:element name="exerciseId" type="xs:string" minOccurs="1"/>
+      <xs:element name="partyId" type="xs:string" minOccurs="1"/>
       <xs:element name="notificationType" type="NotificationType" minOccurs="1"/>
     </xs:all>
   </xs:complexType>


### PR DESCRIPTION
Add `exerciseId` and `partyId` to the message schema used for sending cases from case to action service

[Trello](https://trello.com/c/RfLGapt3/62-extend-representation-of-case-in-action-service)