### PR TITLE
Spurious edit to trigger another maven release in travis

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
+  <!-- Spurious comment to force another maven release -->
+
   <modelVersion>4.0.0</modelVersion>
   <artifactId>casesvc-api</artifactId>
   <version>10.49.22-SNAPSHOT</version>


### PR DESCRIPTION
# Motivation and Context
The maven release of rm-casesvc-api triggered by the last merge to master failed due to a timeout transferring the release artifact to artifactory.  This commit is a spurious change to force another release

# What has changed
- a spurious comment has been added to pom.xml

# How to test?
- check out branch
- run mvn clean install
- ensure no errors

# Links
- [failed travis build](https://travis-ci.org/ONSdigital/rm-casesvc-api/builds/404814945)
