### PR TITLE
Party ID is optional with social surveys

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,13 @@
       <groupId>io.springfox</groupId>
       <artifactId>springfox-swagger2</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>uk.gov.ons.ctp.common</groupId>
+      <artifactId>test-framework</artifactId>
+      <version>10.49.12</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/resources/casesvc/xsd/inbound/SampleUnitNotification.xsd
+++ b/src/main/resources/casesvc/xsd/inbound/SampleUnitNotification.xsd
@@ -30,7 +30,7 @@
             <xs:element name="id" type="xs:string" minOccurs="0" maxOccurs="1"/>
             <xs:element name="sampleUnitRef" type="xs:string" minOccurs="1" maxOccurs="1"/>
             <xs:element name="sampleUnitType" type="xs:string" minOccurs="1" maxOccurs="1"/>
-            <xs:element name="partyId" type="xs:string" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="partyId" type="xs:string" minOccurs="0" maxOccurs="1"/>
             <xs:element name="collectionInstrumentId" type="xs:string" minOccurs="1" maxOccurs="1"/>
             <xs:element name="actionPlanId" type="xs:string" minOccurs="1" maxOccurs="1"/>
         </xs:sequence>

--- a/src/test/java/uk/gov/ons/ctp/response/casesvc/message/sampleunitnotification/SampleUnitParentTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/casesvc/message/sampleunitnotification/SampleUnitParentTest.java
@@ -1,0 +1,39 @@
+package uk.gov.ons.ctp.response.casesvc.message.sampleunitnotification;
+
+import static org.junit.Assert.assertNotNull;
+
+import javax.xml.bind.JAXBContext;
+import org.junit.Test;
+import org.springframework.core.io.ClassRelativeResourceLoader;
+import org.springframework.core.io.ResourceLoader;
+import uk.gov.ons.ctp.common.utility.Mapzer;
+
+public class SampleUnitParentTest {
+
+  @Test
+  public void testPartyIdIsOptional() throws Exception {
+    // Given
+    SampleUnitParent sampleUnitParent =
+        SampleUnitParent.builder()
+            .withCollectionExerciseId("collectionExerciseId")
+            .withSampleUnitType("sampleUnitType")
+            .withCollectionInstrumentId("collectionInstrument")
+            .withActionPlanId("actionPlanId")
+            .withSampleUnitRef("sampleUnitRef")
+            .build();
+
+    // When
+    String xml = validateBySerialisation(sampleUnitParent);
+
+    // Then
+    assertNotNull(xml);
+  }
+
+  private String validateBySerialisation(SampleUnitParent sampleUnitParent) throws Exception {
+    JAXBContext jaxbContext = JAXBContext.newInstance(SampleUnitParent.class);
+    ResourceLoader resourceLoader = new ClassRelativeResourceLoader(SampleUnitParentTest.class);
+    Mapzer mapzer = new Mapzer(resourceLoader);
+    return mapzer.convertObjectToXml(
+        jaxbContext, sampleUnitParent, "casesvc/xsd/inbound/SampleUnitNotification.xsd");
+  }
+}


### PR DESCRIPTION
# Motivation and Context
Social surveys don't have parties but businesses do. The validation for a
sample unit has been relaxed to allow this.

# What has changed
Make party id optional
Add test for optional party id

# How to test?
Run unit tests

# Links
https://trello.com/c/ZFF7x8Za/102-dev-task-3b-int-create-action-service-to-retrieve-new-sample-attributes-13