### PR TITLE
Add partyId element to CaseReceipt message

### DIFF
--- a/src/main/resources/casesvc/xsd/inbound/caseReceipt.xsd
+++ b/src/main/resources/casesvc/xsd/inbound/caseReceipt.xsd
@@ -12,6 +12,7 @@
             <xs:element name="caseId"  type="xs:string" minOccurs="1" maxOccurs="1"/>
             <xs:element name="inboundChannel" type="InboundChannel" minOccurs="1" maxOccurs="1"/>
             <xs:element name="responseDateTime" type="xs:dateTime" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="partyId" type="xs:string" minOccurs="0" maxOccurs="1"/>
         </xs:sequence>
     </xs:complexType>
 

--- a/src/main/resources/casesvc/xsd/inbound/caseReceipt.xsd.xml
+++ b/src/main/resources/casesvc/xsd/inbound/caseReceipt.xsd.xml
@@ -4,4 +4,5 @@
   <caseId>string</caseId>
   <inboundChannel>OFFLINE</inboundChannel>
   <responseDateTime>2007-10-26T07:36:28</responseDateTime>
+  <partyId>string</partyId>
 </feed:caseReceipt>


### PR DESCRIPTION
# Motivation and Context
Since the removal of the BI cases, knowing the case ID is insufficient to know the party (i.e. respondent) who completed a survey. EQ currently only sends back the case ID which was sent in the original payload, when the survey was started.

We send EQ the party ID, but there was no element in place to allow it to be sent back in the XML payload CaseReceipt message.

# What has changed
Added `partyId` to `CaseReceipt` XML schema definition.

# How to test?
It's just a schema. I guess you could use a schema validator to check it, but it seems unnecessary. Can't test. It's preparatory work for some EQ changes and changes to the Case service.

# Links
Trello: https://trello.com/c/RqxRNedI/581-add-userid-to-eq-receipt-payload