### PR TITLE
Adding metadata to caseevents dto

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/representation/CaseEventCreationRequestDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/representation/CaseEventCreationRequestDTO.java
@@ -1,6 +1,7 @@
 package uk.gov.ons.ctp.response.casesvc.representation;
 
 import io.swagger.annotations.ApiModelProperty;
+import java.util.HashMap;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 import lombok.AccessLevel;
@@ -34,4 +35,6 @@ public class CaseEventCreationRequestDTO {
   private String createdBy;
 
   private String subCategory;
+
+  private HashMap<String, String> metadata;
 }

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/representation/CaseEventCreationRequestDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/representation/CaseEventCreationRequestDTO.java
@@ -1,7 +1,7 @@
 package uk.gov.ons.ctp.response.casesvc.representation;
 
 import io.swagger.annotations.ApiModelProperty;
-import java.util.HashMap;
+import java.util.Map;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 import lombok.AccessLevel;
@@ -36,5 +36,5 @@ public class CaseEventCreationRequestDTO {
 
   private String subCategory;
 
-  private HashMap<String, String> metadata;
+  private Map<String, String> metadata;
 }

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/representation/CaseEventDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/representation/CaseEventDTO.java
@@ -1,6 +1,7 @@
 package uk.gov.ons.ctp.response.casesvc.representation;
 
 import java.util.Date;
+import java.util.HashMap;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 import lombok.AccessLevel;
@@ -32,4 +33,6 @@ public class CaseEventDTO {
   @NotNull
   @Size(min = DESC_MIN, max = DESC_MAX)
   private String description;
+
+  private HashMap<String, String> metadata;
 }

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/representation/CaseEventDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/representation/CaseEventDTO.java
@@ -1,7 +1,7 @@
 package uk.gov.ons.ctp.response.casesvc.representation;
 
 import java.util.Date;
-import java.util.HashMap;
+import java.util.Map;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 import lombok.AccessLevel;
@@ -34,5 +34,5 @@ public class CaseEventDTO {
   @Size(min = DESC_MIN, max = DESC_MAX)
   private String description;
 
-  private HashMap<String, String> metadata;
+  private Map<String, String> metadata;
 }

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/representation/CreatedCaseEventDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/representation/CreatedCaseEventDTO.java
@@ -1,7 +1,7 @@
 package uk.gov.ons.ctp.response.casesvc.representation;
 
 import java.util.Date;
-import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
@@ -38,5 +38,5 @@ public class CreatedCaseEventDTO {
   @Size(min = DESC_MIN, max = DESC_MAX)
   private String description;
 
-  private HashMap<String, String> metadata;
+  private Map<String, String> metadata;
 }

--- a/src/main/java/uk/gov/ons/ctp/response/casesvc/representation/CreatedCaseEventDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/response/casesvc/representation/CreatedCaseEventDTO.java
@@ -1,6 +1,7 @@
 package uk.gov.ons.ctp.response.casesvc.representation;
 
 import java.util.Date;
+import java.util.HashMap;
 import java.util.UUID;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
@@ -36,4 +37,6 @@ public class CreatedCaseEventDTO {
   @NotNull
   @Size(min = DESC_MIN, max = DESC_MAX)
   private String description;
+
+  private HashMap<String, String> metadata;
 }


### PR DESCRIPTION
# Motivation and Context
In response-operation-ui, we want to be able to see the respondent name on the responses status page when a external user has completed a collection exercise. For this to happen, a new field needs to be added to the case events dto to be able to store any metadata that can be given to the case service.

# What has changed
- Added metadata to case events table

# How to test?
- Run `mvn clean install` and it should build successfully
- Run with the [case branch](https://github.com/ONSdigital/rm-case-service/tree/adding-metadata-to-caseevents), [R-ops branch](https://github.com/ONSdigital/response-operations-ui/tree/us211-display-respondent-for-seft-rus-ce-in-response-status), [Frontstage branch](https://github.com/ONSdigital/ras-frontstage/tree/us211-display-respondent-for-seft-rus-ce-in-response-status) and complete a SEFT collection exercise. When completed, look on response ops response status page and the completed collex should have a respondent name attached to it.
- Run with acceptance tests

# Links
[Trello](https://trello.com/c/1rcfmtok)
